### PR TITLE
Data table had redundant column

### DIFF
--- a/ch06/hubbub/test/unit/com/grailsinaction/UserControllerSpec.groovy
+++ b/ch06/hubbub/test/unit/com/grailsinaction/UserControllerSpec.groovy
@@ -54,10 +54,13 @@ class UserControllerSpec extends Specification {
         println urc.errors
 
         where:
-        userId  | password   | passwordRepeat| anticipatedValid   | fieldInError       | errorCode
-        "glen"  | "password" | "no-match"   | false               | "passwordRepeat"   | "validator.invalid"
-        "peter" | "password" | "password"   | true                | null               | null
-        "a"     | "password" | "password"   | false               | "userId"           | "size.toosmall"
+        
+        password = 'password'
+        
+        userId  | passwordRepeat | anticipatedValid   | fieldInError       | errorCode
+        "glen"  | "no-match"     | false               | "passwordRepeat"   | "validator.invalid"
+        "peter" | "password"     | true                | null               | null
+        "a"     | "password"     | false               | "userId"           | "size.toosmall"
 
     }
 


### PR DESCRIPTION
In your code, you have a column that is password, but this had the same value - a better approach would be to use the mechanism specified here - http://docs.spockframework.org/en/latest/data_driven_testing.html#combining-data-tables-data-pipes-and-variable-assignments and just have password as it's own field, making your test easier to read
