### PR TITLE
Search query isn't working

### DIFF
--- a/ch05/hubbub/grails-app/controllers/com/grailsinaction/UserController.groovy
+++ b/ch05/hubbub/grails-app/controllers/com/grailsinaction/UserController.groovy
@@ -5,8 +5,8 @@ class UserController {
 
     def search() {}
 
-    def results(String query) {
-        def users = User.where { loginId =~ "%${query}%" }.list()
+    def results(String loginId) {
+        def users = User.where { loginId =~ "%${loginId}%" }.list()
         return [ users: users,
                  term: params.loginId,
                  totalUsers: User.count() ]

--- a/ch05/hubbub/grails-app/views/user/search.gsp
+++ b/ch05/hubbub/grails-app/views/user/search.gsp
@@ -12,6 +12,5 @@
             <g:submitButton name="search" value="Search"/>
         </g:form>
     </formset>
-    <g:textField name="loginId"/>
 </body>
 </html>


### PR DESCRIPTION
The data-binding to the parameter of `UserController.result` was looking for `params.query`. 
As a result, my `users` object was always size 0. 
Either we need to update `search.gsp` to change the name of the textfield from `loginId` to `query` or adjust the parameter name in `UserController.result` to be `loginId` instead of `query`. I chose the second because `loginId` is more consistent with the rest of the app.
